### PR TITLE
Removes the usage of <reset> over closing the formatting tags.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "net.lucypoulton"
-version = "1.3"
+version = "1.4"
 
 repositories {
     mavenCentral()
@@ -20,9 +20,9 @@ tasks.test { useJUnitPlatform() }
 
 
 dependencies {
-    compileOnly(papi("2.11.1"))
+    compileOnly(papi("2.11.2"))
     compileOnly("org.jetbrains:annotations:23.0.0")
-    compileOnly(spigot("1.18.2"))
+    compileOnly(spigot("1.19"))
 
     testImplementation(platform("org.junit:junit-bom:5.8.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")

--- a/src/test/java/net/lucypoulton/kyorify/KyorifierTests.java
+++ b/src/test/java/net/lucypoulton/kyorify/KyorifierTests.java
@@ -26,7 +26,7 @@ public class KyorifierTests {
 
     @Test
     public void givenALegacyFormatterAndColour_expectColourToReset() {
-        assertEquals("<italic>hello <reset><green>world", kyorify("§ohello §aworld"));
+        assertEquals("<italic>hello </italic><green>world", kyorify("§ohello §aworld"));
     }
 
     @Test


### PR DESCRIPTION
As mentioned in #2 the usage of <reset> breaks stuff like <hover> and <click> in MiniMessage as well. To fix this issue, this PR changes the usage of <reset> to closing the currently open formatting tags.

Once again, this closes #2,