### PR TITLE
Update to 1.5.3

### DIFF
--- a/src/main/java/net/lucypoulton/kyorify/KyorifyExpansion.java
+++ b/src/main/java/net/lucypoulton/kyorify/KyorifyExpansion.java
@@ -23,7 +23,7 @@ public class KyorifyExpansion extends PlaceholderExpansion implements Relational
 
     @Override
     public @NotNull String getVersion() {
-        return "1.5.1";
+        return "1.5.3";
     }
 
     private static String log(String str) {


### PR DESCRIPTION
PAPI eCloud needs the correct version set in order to prevent looping upgrades (v1.5.2 would have reported 1.5.1 as version, so eCloud would suggest an update that's not necessary).