### PR TITLE
Update to 1.5.3 in order to eliminate update loops

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "net.lucypoulton"
-version = "1.5.2"
+version = "1.5.3"
 
 repositories {
     mavenCentral()

--- a/src/main/java/net/lucypoulton/kyorify/KyorifyExpansion.java
+++ b/src/main/java/net/lucypoulton/kyorify/KyorifyExpansion.java
@@ -23,7 +23,7 @@ public class KyorifyExpansion extends PlaceholderExpansion implements Relational
 
     @Override
     public @NotNull String getVersion() {
-        return "1.5.1";
+        return "1.5.3";
     }
 
     private static String log(String str) {


### PR DESCRIPTION
As version 1.5.2 reports 1.5.1, PAPI thinks there are updates available, which leads to update loops.